### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-USBKeyboard		KEYWORD1
+USBKeyboard	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update						KEYWORD2
-write						KEYWORD2
-sendKey						KEYWORD2
-sendKeys					KEYWORD2
-asciiToKeycode				KEYWORD2
-asciiToShiftState			KEYWORD2
-isCapsLockActivated			KEYWORD2
-getCapsLockToggleCount		KEYWORD2
+update	KEYWORD2
+write	KEYWORD2
+sendKey	KEYWORD2
+sendKeys	KEYWORD2
+asciiToKeycode	KEYWORD2
+asciiToShiftState	KEYWORD2
+isCapsLockActivated	KEYWORD2
+getCapsLockToggleCount	KEYWORD2
 resetCapsLockToggleCount	KEYWORD2
 
 
@@ -29,7 +29,7 @@ resetCapsLockToggleCount	KEYWORD2
 
 LAYOUT_US	LITERAL1
 LAYOUT_DE	LITERAL1
-CONTROL		LITERAL1
-SHIFT		LITERAL1
-ALT			LITERAL1
-GUI			LITERAL1
+CONTROL	LITERAL1
+SHIFT	LITERAL1
+ALT	LITERAL1
+GUI	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords