### PR TITLE
Change type of array from char to unsigned char

### DIFF
--- a/USBKeyboard.cpp
+++ b/USBKeyboard.cpp
@@ -9,7 +9,7 @@
 
 
 /* set USB HID report descriptor for boot protocol keyboard */
-PROGMEM const char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = {
+PROGMEM const uint8_t usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = {
 	0x05, 0x01,			/* USAGE_PAGE (Generic Desktop)						*/
 	0x09, 0x06,			/* USAGE (Keyboard)									*/
 	0xa1, 0x01,			/* COLLECTION (Application)							*/

--- a/USBKeyboard.cpp
+++ b/USBKeyboard.cpp
@@ -48,8 +48,7 @@ PROGMEM const uint8_t usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGT
 
 /*##################################### PUBLIC FUNCTIONS #####################################*/
 
-/* constructor */
-USBKeyboard::USBKeyboard() {
+void USBKeyboard::begin(uint8_t layout) {
 	cli();
 	USBOUT &= ~USBMASK;
 	USBDDR &= ~USBMASK;
@@ -58,15 +57,8 @@ USBKeyboard::USBKeyboard() {
 	usbDeviceConnect();
 	usbInit();
 	sei();
-}
-
-
-/* constructor */
-USBKeyboard::USBKeyboard(uint8_t layout) {
-	USBKeyboard::USBKeyboard();
 	keyboard_layout = layout;
 }
-
 
 /* make usbPoll() accessable from the outside */
 void USBKeyboard::update() {

--- a/USBKeyboard.h
+++ b/USBKeyboard.h
@@ -43,12 +43,12 @@ static uint8_t keyboard_layout = 0; /* keyboard layout, US layout by standard */
 
 class USBKeyboard : public Print {
 public: /*#################### PUBLIC FUNCTIONS ####################*/
+	USBKeyboard() = default;
+
 	/*******************************************************
-	 * Constructor, call it when initializing the library
+	 * call it when initializing the library
 	 ******************************************************/
-	USBKeyboard();
-	USBKeyboard(uint8_t layout);
-	
+	void begin(uint8_t layout = 0);
 	
 	/*******************************************************
 	 * Call this function at least every 20ms,

--- a/examples/CapsLockToggle/CapsLockToggle.ino
+++ b/examples/CapsLockToggle/CapsLockToggle.ino
@@ -15,13 +15,16 @@
 #define LAYOUT LAYOUT_US
 
 
-/* initialize class by creating object mKeyboard */
+/* create keyboard object mKeyboard */
 USBKeyboard mKeyboard = USBKeyboard();
 
 
 void setup() {
 	/* USB timing has to be exact, therefore deactivate Timer0 interrupt */
 	TIMSK0 = 0;
+
+	/* initialize the keyboard */
+	mKeyboard.begin()
 }
 
 

--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -18,7 +18,7 @@
 #define LAYOUT LAYOUT_US
 
 
-/* initialize class by creating object mKeyboard */
+/* create keyboard object mKeyboard */
 USBKeyboard mKeyboard = USBKeyboard();
 
 bool lastButtonState = HIGH;
@@ -28,6 +28,9 @@ bool lastCapsLockState;
 void setup() {
 	/* USB timing has to be exact, therefore deactivate Timer0 interrupt */
 	TIMSK0 = 0;
+
+	/* initialize the keyboard */
+	mKeyboard.begin()
 	
 	/* set the button pin as input and activate the internal pullup resistor */
 	pinMode(BUTTON_PIN, INPUT_PULLUP);

--- a/examples/SendMultipleKeys/SendMultipleKeys.ino
+++ b/examples/SendMultipleKeys/SendMultipleKeys.ino
@@ -16,13 +16,16 @@
 #define LAYOUT LAYOUT_US
 
 
-/* initialize class by creating object mKeyboard */
+/* create keyboard object mKeyboard */
 USBKeyboard mKeyboard = USBKeyboard();
 
 
 void setup() {
 	/* USB timing has to be exact, therefore deactivate Timer0 interrupt */
 	TIMSK0 = 0;
+
+	/* initialize the keyboard */
+	mKeyboard.begin()
 }
 
 

--- a/keycodes.h
+++ b/keycodes.h
@@ -200,7 +200,7 @@ PROGMEM const uint8_t KEYCODES_LAYOUT_DE[96] = {
 };
 
 
-PROGMEM const char MODIFIER_SHIFT_LAYOUT_US[12] = {
+PROGMEM const uint8_t MODIFIER_SHIFT_LAYOUT_US[12] = {
 	B01111111,	/*		Space	!	"	#	$	%	&	'		*/
 	B11110000,	/*			(	)	*	+	,	-	.	/		*/
 	B00000000,	/*			0	1	2	3	4	5	6	7		*/
@@ -216,7 +216,7 @@ PROGMEM const char MODIFIER_SHIFT_LAYOUT_US[12] = {
 };
 
 
-PROGMEM const char MODIFIER_SHIFT_LAYOUT_DE[12] = {
+PROGMEM const uint8_t MODIFIER_SHIFT_LAYOUT_DE[12] = {
 	B01111111,	/*		Space	!	"	#	$	%	&	'		*/
 	B11100001,	/*			(	)	*	+	,	-	.	/		*/
 	B00000000,	/*			0	1	2	3	4	5	6	7		*/

--- a/usbdrv.h
+++ b/usbdrv.h
@@ -494,7 +494,7 @@ extern
 #if !(USB_CFG_DESCR_PROPS_HID_REPORT & USB_PROP_IS_RAM)
 PROGMEM
 #endif
-const char usbDescriptorHidReport[];
+const uint8_t usbDescriptorHidReport[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_STRING_0 & USB_PROP_IS_RAM)


### PR DESCRIPTION
Change type of some arrays from 'char' to 'uint8_t' (a.k.a unsigned char) to avoid narrowing errors from int to char:

USBKeyboard/keycodes.h:216:1: error: narrowing conversion of '240' from 'int' to 'char' inside { } [-Wnarrowing]

This kind of narrowing is not an error for unsigned types. Whether 'char' is unsigned or signed is implementation defined. Therefore whether or not this error occures depends on compilers, compiler versions …